### PR TITLE
Fix blog card style

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,11 @@ title = 'Maison Hatoyama'
 theme = "PaperMod"
 disqusShortname = "julian-10"
 
+[params]
+  disableSpecial1stPost = true
+
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
+


### PR DESCRIPTION
## Summary
- keep the first post from being shown in "featured" style by default

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68531b20083083249fdf5a7a2261e002