### PR TITLE
Add Windows-style start menu with toggle behavior

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -58,7 +58,17 @@
                 <span id="current-time"></span>
             </div>
         </div>
-        
+
+        <!-- Start Menu (hidden by default) -->
+        <div id="start-menu" class="start-menu">
+            <ul class="menu-list">
+                <li class="menu-item">Programs</li>
+                <li class="menu-item">Documents</li>
+                <li class="menu-item">Settings</li>
+                <li class="menu-item">Run...</li>
+            </ul>
+        </div>
+
         <!-- Main Content Area -->
         <div id="main-content">
             {{- block "main" . }}{{- end }}
@@ -162,7 +172,25 @@
         document.addEventListener('DOMContentLoaded', function() {
             // Initialize theme switcher
             initThemeSwitcher();
-            
+
+            // Start menu toggle
+            const startButton = document.querySelector('.start-button');
+            const startMenu = document.getElementById('start-menu');
+
+            startButton.addEventListener('click', function(e) {
+                e.stopPropagation();
+                const isVisible = startMenu.style.display === 'block';
+                startMenu.style.display = isVisible ? 'none' : 'block';
+            });
+
+            startMenu.addEventListener('click', function(e) {
+                e.stopPropagation();
+            });
+
+            document.addEventListener('click', function() {
+                startMenu.style.display = 'none';
+            });
+
             // Make windows draggable (basic implementation)
             const titleBars = document.querySelectorAll('.title-bar');
             titleBars.forEach(titleBar => {

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -525,6 +525,46 @@ img {
     padding: 3px 6px;
 }
 
+/* Start Menu */
+#start-menu {
+    position: fixed;
+    bottom: 28px;
+    left: 0;
+    width: 200px;
+    background: var(--win98-surface);
+    border-left: 2px solid var(--win98-raised-outer);
+    border-top: 2px solid var(--win98-raised-outer);
+    border-right: 2px solid var(--win98-sunken-outer);
+    border-bottom: 2px solid var(--win98-sunken-outer);
+    display: none;
+    z-index: 1001;
+    box-shadow: 2px 2px 0 var(--win98-sunken-inner);
+}
+
+#start-menu .menu-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+}
+
+#start-menu .menu-item {
+    padding: 4px 12px;
+    cursor: pointer;
+}
+
+#start-menu .menu-item:hover {
+    background: var(--win98-dialog-blue);
+    color: var(--win98-text-white);
+}
+
+/* Windows XP Start Menu */
+:root[data-theme="winxp"] #start-menu {
+    background: #ece9d8;
+    border: 1px solid #aca899;
+    border-radius: 8px 8px 8px 0;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+}
+
 .taskbar-time {
     background: var(--win98-surface);
     border-left: 1px solid var(--win98-sunken-outer);


### PR DESCRIPTION
## Summary
- Add hidden Windows-style start menu markup near the taskbar
- Style start menu for Win98/XP themes and hide it by default
- Toggle start menu visibility via Start button and close when clicking elsewhere

## Testing
- `hugo --destination /tmp/site-build` *(fails: template for shortcode "rawhtml" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf558132d8832487b94da35851b899